### PR TITLE
Made java installation conditional

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,10 @@
 class cassandra::install {
 
-    package { 'java':
+    if !defined (Package['java']) {
+      package { 'java':
         ensure  => installed,
         name    => 'openjdk-7-jre'
+      }
     }
 
     package { 'dsc':


### PR DESCRIPTION
There may be java installation called from different module which can cause duplicate declaration.
Making java installation conditional will avoid duplication.
