### PR TITLE
2.0: fix initial_token/rpc_min_threads/rpc_max_threads

### DIFF
--- a/templates/cassandra2.0.yaml.erb
+++ b/templates/cassandra2.0.yaml.erb
@@ -29,7 +29,9 @@ num_tokens: <%= @num_tokens %>
 # vnodes (num_tokens > 1, above) -- in which case you should provide a 
 # comma-separated list -- it's primarily used when adding nodes # to legacy clusters 
 # that do not have vnodes enabled.
+<% unless @initial_token.nil? || @initial_token.empty? -%>
 initial_token: <%= @initial_token %>
+<% end -%>
 
 # See http://wiki.apache.org/cassandra/HintedHandoff
 hinted_handoff_enabled: true

--- a/templates/cassandra2.0.yaml.erb
+++ b/templates/cassandra2.0.yaml.erb
@@ -371,6 +371,12 @@ rpc_server_type: <%= @rpc_server_type %>
 #
 # rpc_min_threads: 16
 # rpc_max_threads: 2048
+<% if @rpc_min_threads > 0 -%>
+rpc_min_threads: <%= @rpc_min_threads %>
+<% end -%>
+<% if @rpc_max_threads > 0 -%>
+rpc_max_threads: <%= @rpc_max_threads %>
+<% end -%>
 
 # uncomment to set socket buffer sizes on rpc connections
 # rpc_send_buff_size_in_bytes:


### PR DESCRIPTION
- don't write 'initial_token' to config if unset
  From the [manual](http://www.datastax.com/documentation/cassandra/2.0/cassandra/configuration/configVnodesEnable_t.html): The recommended value is 256. Do not set the initial_token parameter.
-  write rpc_min_threads/rpc_max_threads to config (as in 2.1 config)
