### PR TITLE
Add support for broadcast_rpc_address

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,7 @@ class cassandra::config(
     $authenticator,
     $authorizer,
     $rpc_address,
+    $rpc_broadcast_address,
     $rpc_port,
     $rpc_server_type,
     $rpc_min_threads,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@ class cassandra(
     $start_native_transport                 = $cassandra::params::start_native_transport,
     $start_rpc                              = $cassandra::params::start_rpc,
     $rpc_address                            = $cassandra::params::rpc_address,
+    $rpc_broadcast_address                  = $cassandra::params::rpc_broadcast_address,
     $rpc_port                               = $cassandra::params::rpc_port,
     $rpc_server_type                        = $cassandra::params::rpc_server_type,
     $rpc_min_threads                        = $cassandra::params::rpc_min_threads,
@@ -128,6 +129,10 @@ class cassandra(
         fail('rpc_address must be an IP address')
     }
 
+    if(!empty($rpc_broadcast_address) and !is_ip_address($rpc_broadcast_address)) {
+        fail('rpc_broadcast_address must be an IP address')
+    }
+
     if(!is_integer($rpc_port)) {
         fail('rpc_port must be a port number between 1 and 65535')
     }
@@ -200,6 +205,7 @@ class cassandra(
         authenticator                         => $authenticator,
         authorizer                            => $authorizer,
         rpc_address                           => $rpc_address,
+        rpc_broadcast_address                 => $rpc_broadcast_address,
         rpc_port                              => $rpc_port,
         rpc_server_type                       => $rpc_server_type,
         rpc_min_threads                       => $rpc_min_threads,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -153,6 +153,11 @@ class cassandra::params {
         default => $::cassandra_rpc_address,
     }
 
+    $rpc_broadcast_address = $::cassandra_rpc_broadcast_address ? {
+        undef   => '',
+        default => $::cassandra_rpc_broadcast_address,
+    }
+
     $rpc_port = $::cassandra_rpc_port ? {
         undef   => 9160,
         default => $::cassandra_rpc_port,

--- a/templates/cassandra2.1.yaml.erb
+++ b/templates/cassandra2.1.yaml.erb
@@ -428,6 +428,9 @@ rpc_port: <%= @rpc_port %>
 # rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
 # be set.
 # broadcast_rpc_address: 1.2.3.4
+<% unless @rpc_broadcast_address.nil? || @rpc_broadcast_address.empty? %>
+broadcast_rpc_address: <%= @rpc_broadcast_address %>
+<% end %>
 
 # enable or disable keepalive on rpc/native connections
 rpc_keepalive: true


### PR DESCRIPTION
This is to deal with a problem with the datastax-agent that will still
try and connect to 127.0.0.1, even though rpc_address is set to an
external address. This only seems to happen ~50% of the time and the
only solution is to listen everywhere, which requires supporting
broadcast_rpc_address.
